### PR TITLE
refactor: use Sub::Meta v0.05

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,7 +1,7 @@
 requires 'perl', '5.010001';
 requires 'Carp';
 requires 'Scalar::Util';
-requires 'Sub::Meta', '0.04';
+requires 'Sub::Meta', '0.05';
 requires 'Type::Tiny', '1.010004';
 requires 'Sub::WrapInType', '0.03';
 requires 'Moo', '2.004004';

--- a/lib/Types/TypedCodeRef.pm
+++ b/lib/Types/TypedCodeRef.pm
@@ -22,30 +22,9 @@ use Types::TypedCodeRef::Factory;
 sub get_sub_meta_from_sub_wrap_in_type {
   my $typed_code_ref = shift;
   if ( Scalar::Util::blessed($typed_code_ref) && $typed_code_ref->isa('Sub::WrapInType') ) {
-    my @parameters = do {
-      if (ref $typed_code_ref->params eq 'ARRAY') {
-        map { Sub::Meta::Param->new($_) } @{ $typed_code_ref->params };
-      }
-      elsif (ref $typed_code_ref->params eq 'HASH') {
-        map {
-          Sub::Meta::Param->new({
-            name  => $_,
-            type  => $typed_code_ref->params->{$_},
-            named => 1,
-          });
-        } sort keys %{ $typed_code_ref->params };
-      }
-      else {
-        Sub::Meta::Param->new($typed_code_ref->params);
-      }
-    };
     return Sub::Meta->new(
-      parameters => Sub::Meta::Parameters->new(args => \@parameters),
-      returns    => Sub::Meta::Returns->new(
-        scalar => $typed_code_ref->returns,
-        list   => $typed_code_ref->returns,
-        void   => $typed_code_ref->returns,
-      ),
+      args    => $typed_code_ref->params,
+      returns => $typed_code_ref->returns,
     );
   }
   return;

--- a/lib/Types/TypedCodeRef/Factory.pm
+++ b/lib/Types/TypedCodeRef/Factory.pm
@@ -12,9 +12,6 @@ use Type::Params qw( compile compile_named multisig );
 use Types::Standard -types;
 use Scalar::Util;
 use Sub::Meta;
-use Sub::Meta::Param;
-use Sub::Meta::Parameters;
-use Sub::Meta::Returns;
 use Sub::WrapInType qw( wrap_sub );
 use Carp qw( croak );
 use namespace::autoclean;
@@ -103,32 +100,8 @@ sub constraint_generator {
         my ($params, $returns) = $validator->(@_);
 
         Sub::Meta->new(
-          parameters => do {
-            my @meta_params = do {
-              if ( ref $params eq 'ARRAY' ) {
-                map { Sub::Meta::Param->new($_) } @$params;
-              }
-              elsif ( ref $params eq 'HASH' ) {
-                map {
-                  Sub::Meta::Param->new({
-                    name  => $_,
-                    type  => $params->{$_},
-                    named => 1,
-                  });
-                }
-                sort keys %$params;
-              }
-              else {
-                Sub::Meta::Param->new($params);
-              }
-            };
-            Sub::Meta::Parameters->new(args => \@meta_params);
-          },
-          returns => Sub::Meta::Returns->new(
-            scalar => $returns,
-            list   => $returns,
-            void   => $returns,
-          ),
+          args    => $params,
+          returns => $returns,
         );
       }
       else {
@@ -155,11 +128,7 @@ sub find_sub_meta {
 
 sub create_unknown_sub_meta {
   Sub::Meta->new(
-    parameters => Sub::Meta::Parameters->new(
-      args   => [],
-      slurpy => 1,
-    ),
-    returns => Sub::Meta::Returns->new(),
+    slurpy => 1,
   );
 }
 


### PR DESCRIPTION
Since Sub::Meta 0.05, the Sub::Meta constructor has been more flexible, so I removed the unnecessary code in Types::TypedCodeRef.

