### PR TITLE
use wrap_method

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -3,7 +3,7 @@ requires 'Carp';
 requires 'Scalar::Util';
 requires 'Sub::Meta', '0.05';
 requires 'Type::Tiny', '1.010004';
-requires 'Sub::WrapInType', '0.03';
+requires 'Sub::WrapInType', '0.05';
 requires 'Moo', '2.004004';
 requires 'namespace::autoclean', '0.29';
 

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -436,10 +436,10 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Scalar::Util 0
       perl 5.006
-  Sub-WrapInType-0.04
-    pathname: M/MP/MPOLIIU/Sub-WrapInType-0.04.tar.gz
+  Sub-WrapInType-0.05
+    pathname: M/MP/MPOLIIU/Sub-WrapInType-0.05.tar.gz
     provides:
-      Sub::WrapInType 0.04
+      Sub::WrapInType 0.05
     requirements:
       Carp 0
       Class::InsideOut 0

--- a/lib/Types/TypedCodeRef.pm
+++ b/lib/Types/TypedCodeRef.pm
@@ -23,8 +23,9 @@ sub get_sub_meta_from_sub_wrap_in_type {
   my $typed_code_ref = shift;
   if ( Scalar::Util::blessed($typed_code_ref) && $typed_code_ref->isa('Sub::WrapInType') ) {
     return Sub::Meta->new(
-      args    => $typed_code_ref->params,
-      returns => $typed_code_ref->returns,
+      args      => $typed_code_ref->params,
+      returns   => $typed_code_ref->returns,
+      is_method => $typed_code_ref->is_method,
     );
   }
   return;

--- a/t/01_typed_code_ref.t
+++ b/t/01_typed_code_ref.t
@@ -57,4 +57,15 @@ subtest 'empty type parameters' => sub {
   is $type->get_message(undef), q{Undef did not pass type constraint "TypedCodeRef[]"};
 };
 
+subtest 'method' => sub {
+  my $meta = Sub::Meta->new(
+      args      => Int,
+      returns   => Int,
+      is_method => 1
+  );
+  my $type = TypedCodeRef[$meta];
+  ok !$type->check(wrap_sub Int ,=> Int, sub { $_[0] ** 2 } );
+  ok $type->check(wrap_method Int ,=> Int, sub { $_[0] ** 2 } );
+};
+
 done_testing;


### PR DESCRIPTION
Use `wrap_method` when `Sub::Meta` is a method case.

See this pull request for Sub::WrapInType#wrap_method:  https://github.com/ybrliiu/p5-Sub-WrapInType/pull/4

